### PR TITLE
Fix crash in Python 3 if c is None

### DIFF
--- a/omero_reader/__init__.py
+++ b/omero_reader/__init__.py
@@ -225,7 +225,7 @@ class OmeroReader(object):
             message = "T index %s exceeds sizeT %s" % \
                       (t, self.pixels.getSizeT().val)
             log.error(message)
-        if c >= self.pixels.getSizeC().val:
+        if (c or 0) >= self.pixels.getSizeC().val:
             message = "C index %s exceeds sizeC %s" % \
                       (c, self.pixels.getSizeC().val)
             log.error(message)


### PR DESCRIPTION
Found while working on CellProfiler & Omero-py integration.

If supplied `read()` parameters for `c` and `index` are both `None` (which happens when viewing an image in the Images CP module), the reader will crash as `c` remains as `None` when compared to the number of available channels. This step is only needed to validate that the channel number makes sense.

In Python 2 this wouldn't cause an error as `None` is considered as falsey, but in Python 3 you can't use `>` against `None`. I believe the solution is just to substitute in 0 if the parameter isn't supplied.